### PR TITLE
使用deploy参数限制cpu的使用

### DIFF
--- a/deploy/dnf/docker-compose.yaml
+++ b/deploy/dnf/docker-compose.yaml
@@ -35,7 +35,11 @@ services:
     shm_size: 8g
     memswap_limit: -1
     mem_limit: 1g
-    cpu_count: 1
+    # cpu_count: 1 // 没有生效 使用deploy参数限制cpu
+    deploy:
+      resources:
+        limits:
+          cpus: "1.00"
     networks:
       - local
     restart: always


### PR DESCRIPTION
在我的环境下 cpu_count 没有限制到cpu的使用 修改为deploy 测试有效
``` 
Client: Docker Engine - Community
 Version:           20.10.5
 API version:       1.41
 Go version:        go1.13.15
 Git commit:        55c4c88
 Built:             Tue Mar  2 20:33:55 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.12
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.16.12
  Git commit:       459d0df
  Built:            Mon Dec 13 11:44:05 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.4.3
  GitCommit:        269548fa27e0089a8b8278fc4fc781d7f65a939b
 runc:
  Version:          1.0.0-rc92
  GitCommit:        ff819c7e9184c13b7c2607fe6c30ae19403a7aff
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

#### 修改前
![before_modify](https://user-images.githubusercontent.com/25213792/146633337-69224d37-e9b7-43de-b3d8-2b4428a4351f.png)

#### 修改后
![after_modify](https://user-images.githubusercontent.com/25213792/146633357-a39027ec-ed0d-412e-b2f8-091dd0433e3f.png)

