### PR TITLE
update deploy option shm_size comment

### DIFF
--- a/Kubernetes.md
+++ b/Kubernetes.md
@@ -56,6 +56,7 @@ spec:
       - name: dnf
         persistentVolumeClaim:
           claimName: dnf
+      # 【不可删除】，docker等容器运行时默认较小，需要增加才能保证运行
       - name: memory
         emptyDir:
           medium: Memory

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ mkdir -p /data/log /data/mysql /data/data
 # DNF_DB_ROOT_PASSWORD为mysql root密码,容器启动是root密码会跟随该环境变量的变化自动更新
 # WEB_USER为supervisor web管理页面用户名
 # WEB_PASS为supervisor web管理页面密码(可以访问PUBLIC_IP:2000来访问进程管理页面)
+# --shm-size=8g【不可删除】，docker默认为64M较小，需要增加才能保证运行
 docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -v /data/log:/home/neople/game/log -v /data/mysql:/var/lib/mysql -v /data/data:/data -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 10011:10011/tcp -p 11011:11011/udp -p 10052:10052/tcp -p 11052:11052/udp -p 7200:7200/tcp -p 7200:7200/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.4.fix1
 ```
 

--- a/deploy/dnf/docker-compose.yaml
+++ b/deploy/dnf/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       # 开启DDNS[可选配置]
       # - DDNS_ENABLE=true
       # - DDNS_DOMAIN=''
+    # shm_size: 8g【不可删除】，docker默认为64M较小，需要增加才能保证运行
     shm_size: 8g
     memswap_limit: -1
     mem_limit: 1g


### PR DESCRIPTION
目前发现多名群友在配置较高时，误删shm_size配置，导致服务端无法启动，重点加了注释，用于防止类似问题再次发生