### PR TITLE
fix: reduce cpu usage in dp mode

### DIFF
--- a/build/dnf_data/init.sh
+++ b/build/dnf_data/init.sh
@@ -96,7 +96,7 @@ if [ -z "$MYSQL_HOST" ] && [ -z "$MYSQL_PORT" ];then
     service mysql start
     /usr/bin/mysqladmin -u root password $DNF_DB_ROOT_PASSWORD
     initMysql
-    service mysql stop      
+    service mysql stop
   else
     echo "local mysql data already inited."
   fi
@@ -221,6 +221,7 @@ if [ ! -f "/data/dp/libhook.so" ];then
 else
   echo "libhook.so have already inited, do nothing!"
 fi
+
 # 判断supervisor dnf 配置是否初始化
 if [ ! -f "/data/conf.d/dnf.conf" ];then
   cp /home/template/init/supervisor/dnf.conf /data/conf.d/

--- a/build/dnf_data/supervisor/dnf.conf
+++ b/build/dnf_data/supervisor/dnf.conf
@@ -41,7 +41,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=stun
 
 [program:manager]
@@ -52,7 +52,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=monitor
 
 [program:relay]
@@ -73,7 +73,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=relay
 
 [program:dbmw_guild]
@@ -84,7 +84,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=channel
 
 [program:dbmw_mnt]
@@ -95,7 +95,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=dbmw_guild
 
 [program:dbmw_stat]
@@ -106,7 +106,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=dbmw_mnt
 
 [program:auction]
@@ -139,7 +139,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=point
 
 [program:statics]
@@ -150,7 +150,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=guild
 
 [program:coserver]
@@ -161,7 +161,7 @@ autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
-environment=LD_PRELOAD=/dp2/libhook.so
+environment=LD_PRELOAD=/home/template/init/libhook.so
 depend=statics
 
 [program:community]


### PR DESCRIPTION
参考神迹的脚本，修改了启动配置，这些进程不需要加载dp。

原脚本如下：
```sh
echo 1 > /proc/sys/vm/drop_caches
echo 2 > /proc/sys/vm/drop_caches
echo 3 > /proc/sys/vm/drop_caches
echo -e "\033[42;37m[!] 内存已释放  \033[0m"
echo -e "\033[43;37m[!] 内存使用情况 : \033[0m"
free -m

echo -e "\033[46;37m[!] 正在同步系统时间 : \033[0m"
service ntpd stop
ntpdate -t 5 ntp2.aliyun.com
service ntpd restart

echo -e "\033[46;37m[!] 启动MySQL数据库 \033[0m"
cd /opt/lampp
./lampp startmysql

echo -e "\033[46;37m[!] 启动服务端 \033[0m"
cd /home/neople/stun
chmod 777 *
rm -f  /home/neople/stun/pid/*.pid
rm -rf /home/neople/stun/log/*.*
./df_stun_r start &

cd /home/neople/monitor
chmod 777 *
rm -f  /home/neople/monitor/pid/*.pid
rm -rf  /home/neople/monitor/log/*.*
./df_monitor_r mnt_siroco start &

cd /home/neople/manager
chmod 777 *
rm -f  /home/neople/manager/pid/*.pid
rm -rf  /home/neople/manager/log/*.*
./df_manager_r manager start &

cd /home/neople/relay
chmod 777 *
rm -f  /home/neople/relay/pid/*.pid
rm -rf  /home/neople/relay/log/*.*
./df_relay_r relay_200 start &

cd /home/neople/bridge
chmod 777 *
rm -f  /home/neople/bridge/pid/*.pid
rm -rf  /home/neople/bridge/log/*.*
./df_bridge_r bridge start &

cd /home/neople/channel
chmod 777 *
rm -f  /home/neople/channel/pid/*.pid
rm -rf  /home/neople/channel/log/*.*
while true; do
  nc -z 127.0.0.1 7000 > /dev/null 2>&1
  if [ $? -eq 0 ]; then
    echo "bridge服务7000端口已就绪. 启动channel服务."
    nohup ./channel_amd64 channel start > /home/neople/channel/log/channel_amd64.log 2>&1 &
    break
  fi
  echo "等待bridge服务7000端口启动."
  sleep 5
done

cd /home/neople/dbmw_guild
chmod 777 *
rm -f  /home/neople/dbmw_guild/pid/*.pid
rm -rf  /home/neople/dbmw_guild/log/*.*
./df_dbmw_r dbmw_gld_siroco start &

cd /home/neople/dbmw_mnt
chmod 777 *
rm -f  /home/neople/dbmw_mnt/pid/*.pid
rm -rf  /home/neople/dbmw_mnt/log/*.*
./df_dbmw_r dbmw_mnt_siroco start &

cd /home/neople/dbmw_stat
chmod 777 *
rm -f  /home/neople/dbmw_stat/pid/*.pid
rm -rf  /home/neople/dbmw_stat/log/*.*
./df_dbmw_r dbmw_stat_siroco start &

cd /home/neople/auction
chmod 777 *
rm -f  /home/neople/auction/pid/*.pid
rm -rf  /home/neople/auction/log/*.*
./df_auction_r ./cfg/auction_siroco.cfg start ./df_auction_r &

cd /home/neople/point
chmod 777 *
rm -f  /home/neople/point/pid/*.pid
rm -rf  /home/neople/point/log/*.*
./df_point_r ./cfg/point_siroco.cfg start df_point_r &

cd /home/neople/guild
chmod 777 *
rm -f  /home/neople/guild/pid/*.pid
rm -rf  /home/neople/guild/log/*.*
./df_guild_r gld_siroco start &

cd /home/neople/statics
chmod 777 *
rm -f  /home/neople/statics/pid/*.pid
rm -rf  /home/neople/statics/log/*.*
./df_statics_r stat_siroco start &

cd /home/neople/coserver
chmod 777 *
rm -f  /home/neople/coserver/pid/*.pid
rm -rf  /home/neople/coserver/log/*.*
./df_coserver_r coserver start &

cd /home/neople/community
chmod 777 *
rm -f /home/neople/community/pid/*.pid
rm -rf /home/neople/community/log/*.*
./df_community_r community start &

cd /home/neople/secsvr/gunnersvr
chmod 777 *
rm -f /home/neople/secsvr/gunnersvr/*.pid

./gunnersvr -t30 -i1  &

cd /home/neople/secsvr/zergsvr
chmod 777 *
rm -f /home/neople/secsvr/zergsvr/*.pid

./secagent  &
./zergsvr -t30 -i1  &

sleep 2
echo -e "\033[46;37m[!] 启动网页版GM \033[0m"
cd /root/dist/
./godofgm -x &
echo -e "\033[42;37m[!] 启动成功 , 网页版GM访问地址 : 192.168.200.131:8088 \033[0m"

cd /home/neople/game
chmod 777 *
rm -rf /home/neople/game/log/*

sleep 10
echo -e "\033[44;37m[!] 启动11频道 + DP"
LD_PRELOAD=/dp2/libdp2pre.so ./df_game_r siroco11 start &

sleep 10
echo -e "\033[44;37m[!] 启动56PVP频道"
./df_game_r siroco56 start &

```