### PR TITLE
fix env err in `init_local_db.sh` file

### DIFF
--- a/build/dnf_data/home/template/init/init_local_db.sh
+++ b/build/dnf_data/home/template/init/init_local_db.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # 判断本地数据库是否初始化过,端口号4000
-if [ -z "$MASTER_MYSQL_HOST" ] && [ -z "$MASTER_MYSQL_PORT" ] && [ -z "$MYSQL_HOST" ] && [ -z "$MYSQL_PORT" ];then
+if [ -z "$MAIN_MYSQL_HOST" ] && [ -z "$MAIN_MYSQL_PORT" ] && [ -z "$MYSQL_HOST" ] && [ -z "$MYSQL_PORT" ];then
   echo "use local mysql service"
   # 是否需要初始化
   if [ ! -d "/var/lib/mysql/mysql" ];then


### PR DESCRIPTION
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/6f830299-805b-4d6d-b7a8-db8933cbc960" />

如上图所示，在初始化本地数据库时，有环境变量取值错误，并未有MASTER开头的环境变量，而是MAIN开头的相关数据库变量，已将MASTER改为MAIN