### PR TITLE
Update OtherDeploy.md

### DIFF
--- a/build/dnf_data/home/template/init/run/start_channel.sh
+++ b/build/dnf_data/home/template/init/run/start_channel.sh
@@ -34,6 +34,6 @@ rm -rf /tmp/channel.cfg
 # 启动服务
 echo "starting channel..."
 # 使用默认的libhook.so降低CPU占用
-LD_PRELOAD=/home/template/init/libhook.so ./df_channel_r channel start
+LD_PRELOAD=/dp2/libhook.so ./df_channel_r channel start
 sleep 2
 cat pid/*.pid |xargs -n1 -I{} tail --pid={} -f /dev/null

--- a/build/dnf_data/home/template/init/run/start_channel.sh
+++ b/build/dnf_data/home/template/init/run/start_channel.sh
@@ -33,7 +33,7 @@ cp /tmp/channel.cfg /home/neople/channel/cfg/channel.cfg
 rm -rf /tmp/channel.cfg
 # 启动服务
 echo "starting channel..."
-# 使用默认的libhook.so降低CPU占用
+# 加载DP并启动,该DP可以被自定义[确保DP路径已经被正确映射]
 LD_PRELOAD=/dp2/libhook.so ./df_channel_r channel start
 sleep 2
 cat pid/*.pid |xargs -n1 -I{} tail --pid={} -f /dev/null

--- a/build/dnf_data/home/template/init/run/start_channel.sh
+++ b/build/dnf_data/home/template/init/run/start_channel.sh
@@ -33,7 +33,7 @@ cp /tmp/channel.cfg /home/neople/channel/cfg/channel.cfg
 rm -rf /tmp/channel.cfg
 # 启动服务
 echo "starting channel..."
-# 加载DP并启动[确保DP路径已经被正确映射]
-LD_PRELOAD=/dp2/libhook.so ./df_channel_r channel start
+# 使用默认的libhook.so降低CPU占用
+LD_PRELOAD=/home/template/init/libhook.so ./df_channel_r channel start
 sleep 2
 cat pid/*.pid |xargs -n1 -I{} tail --pid={} -f /dev/null

--- a/doc/OtherDeploy.md
+++ b/doc/OtherDeploy.md
@@ -66,7 +66,7 @@
 | 环境变量名称 | 描述 | 可选参数 | 默认值 |
 | ------- | ------- | ------- | ------- |
 | SERVER_GROUP | 大区编号 | 1-6范围的数字 | 3 |
-| SERVER_GROUP_DB | 大区数据库 | 所有大区名称 | '' |
+| SERVER_GROUP_DB | 大区数据库 | 所有大区名称 | cain |
 | OPEN_CHANNEL | 开启的频道 | 支持配置范围,配置之间用逗号分隔,例如:1-11,12,22-25,51-55 | '11,52' |
 | DNF_DB_ROOT_PASSWORD | DNF数据库root密码[当使用独立数据库时,root密码用于初始化数据以及game账号自动化创建、授权] |  | '' |
 | DNF_DB_GAME_PASSWORD | DNF数据库game密码[必须8位] |  | '' |
@@ -97,7 +97,7 @@
 | 环境变量名称 | 描述 | 可选参数 | 默认值 |
 | ------- | ------- | ------- | ------- |
 | SERVER_GROUP | 大区编号 | 1-6范围的数字 | 3 |
-| SERVER_GROUP_DB | 大区数据库 | 所有大区名称 | '' |
+| SERVER_GROUP_DB | 大区数据库 | 所有大区名称 | cain |
 | MAIN_BRIDGE_IP | 主大区 BRIDGE_IP | 主大区的PUBLIC_IP地址 | 127.0.0.1 |
 | MAIN_MYSQL_HOST | 主数据库IP地址 |  | '' |
 | MAIN_MYSQL_PORT | 主数据库端口号 |  | '' |


### PR DESCRIPTION
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/0672f310-7918-4f47-92cc-2e70bc624844" />

Dockerfile中已设置SERVER_GROUP_DB为cain，与文档中描述的默认值不一致，已更新文档默认值描述

同时在挂载DP时，仅df_game_r服务需要挂载DP，df_channel_r使用默认的libhook.so即可