### PR TITLE
fix ddns ip is empty

### DIFF
--- a/build/dnf_data/home/template/init/monitor_ip/monitor_ip.sh
+++ b/build/dnf_data/home/template/init/monitor_ip/monitor_ip.sh
@@ -54,6 +54,14 @@ do
   old_ip=$(cat /data/monitor_ip/MONITOR_PUBLIC_IP 2>/dev/null || true)
   nslookup_output=$(nslookup -debug $DDNS_DOMAIN 2>/dev/null || true)
   ddns_ip=$(echo "$nslookup_output" | awk '/^Address: / { print $2 }')
+  # 判断ddns_ip是否为空
+  if [ -z "$ddns_ip" ]; then
+    echo "ddns ip is empty, wait $wait_time second"
+    # 等待
+    sleep $wait_time
+    continue
+  fi
+  # 判断ddns_ip是否发生变化
   if [ "$ddns_ip" != "$old_ip" ] ; then
     echo "domain ip changed, old ip is $old_ip, new ip is $ddns_ip"
     # 通知其他进程[写入文件]
@@ -76,6 +84,14 @@ while [ -z "$MONITOR_PUBLIC_IP" ] && [ "$DDNS_ENABLE" = true ];
 do
   old_ip=$(cat /data/monitor_ip/MONITOR_PUBLIC_IP 2>/dev/null || true)
   ddns_ip=$(/data/monitor_ip/get_ddns_ip.sh 2>/dev/null || true)
+  # 判断ddns_ip是否为空
+  if [ -z "$ddns_ip" ]; then
+    echo "ddns ip is empty, wait $wait_time second"
+    # 等待
+    sleep $wait_time
+    continue
+  fi
+  # 判断ddns_ip是否发生变化
   if [ "$ddns_ip" != "$old_ip" ] ; then
     echo "net ip changed, old ip is $old_ip, new ip is $ddns_ip"
     # 通知其他进程[写入文件]


### PR DESCRIPTION
<img width="830" alt="image" src="https://github.com/user-attachments/assets/b8f60695-5d56-4377-8532-14ca14b8f120" />

目前发现在ddns获取ip时，如果外部服务不稳定，请求失败导致获取到的ip为空，会导致服务频繁重启，如上日志所述

脚本判断ip发生了变化，进而重启了df_game_r