### PR TITLE
Fix incorrect gunnersvr pid path in start_gunnersvr.sh

### DIFF
--- a/build/dnf_data/home/template/init/run/start_gunnersvr.sh
+++ b/build/dnf_data/home/template/init/run/start_gunnersvr.sh
@@ -1,7 +1,7 @@
 # /bin/bash
 
 killall -9 gunnersvr
-rm -rf pid/*.pid
+rm -rf *.pid
 ./gunnersvr -t30 -i1
 sleep 2
-cat pid/*.pid |xargs -n1 -I{} tail --pid={} -f /dev/null
+cat *.pid |xargs -n1 -I{} tail --pid={} -f /dev/null


### PR DESCRIPTION
原脚本中关于 gunnersvr 的 pid 文件路径存在错误，此 PR 已调整为正确路径