### PR TITLE
docs: 部署 DNF 不再要求关闭宿主机 SELinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ mkdir -p /data/log /data/mysql /data/data
 # --shm-size=8g【不可删除】，docker默认为64M较小，需要增加才能保证运行
 # 注意，最后的 1995chen/dnf:centos5-2.1.5 部分中的 centos5，你在上一步(环境配置)拉取得哪个版本，则应替换为哪个版本
 # tailscale需要额外映射设备: --device /dev/net/tun:/dev/net/tun
-docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -e CLIENT_POOL_SIZE=10 -v /data/log:/home/neople/game/log -v /data/mysql:/var/lib/mysql -v /data/data:/data -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 30011:30011/tcp -p 31011:31011/udp -p 30052:30052/tcp -p 31052:31052/udp -p 7300:7300/tcp -p 7300:7300/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.9.fix1
+docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -e CLIENT_POOL_SIZE=10 -v /data/log:/home/neople/game/log:Z -v /data/mysql:/var/lib/mysql:Z -v /data/data:/data:Z -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 30011:30011/tcp -p 31011:31011/udp -p 30052:30052/tcp -p 31052:31052/udp -p 7300:7300/tcp -p 7300:7300/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.9.fix1
 ```
 
 ## 如何确认已经成功启动

--- a/deploy/dnf/docker-compose/basic/docker-compose.yaml
+++ b/deploy/dnf/docker-compose/basic/docker-compose.yaml
@@ -54,6 +54,6 @@ services:
       - 31052:31052/udp           # df_game_r[ch.52]
       - 2311-2313:2311-2313/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./mysql:/var/lib/mysql
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./mysql:/var/lib/mysql:Z
+      - ./log:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/multi_channel/docker-compose.yaml
+++ b/deploy/dnf/docker-compose/multi_channel/docker-compose.yaml
@@ -42,6 +42,6 @@ services:
       - 31007:31007/udp           # df_game_r[ch.07]
       - 2311-2313:2311-2313/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./mysql:/var/lib/mysql
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./mysql:/var/lib/mysql:Z
+      - ./log:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/multi_server_group/cain.yaml
+++ b/deploy/dnf/docker-compose/multi_server_group/cain.yaml
@@ -11,7 +11,7 @@ services:
       ports:
         - "3000:3306"
       volumes:
-        - ./mysql:/var/lib/mysql
+        - ./mysql:/var/lib/mysql:Z
       restart: always
 
   dnf-1:
@@ -58,5 +58,5 @@ services:
       - 11052:11052/udp           # df_game_r[ch.52]
       - 2111-2113:2111-2113/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./log:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/multi_server_group/combine_server_group.yaml
+++ b/deploy/dnf/docker-compose/multi_server_group/combine_server_group.yaml
@@ -11,7 +11,7 @@ services:
       ports:
         - "3001:3306"
       volumes:
-        - ./mysql_cain:/var/lib/mysql
+        - ./mysql_cain:/var/lib/mysql:Z
       restart: always
 
   mysql-diregie:
@@ -23,7 +23,7 @@ services:
       ports:
         - "3002:3306"
       volumes:
-        - ./mysql_diregie:/var/lib/mysql
+        - ./mysql_diregie:/var/lib/mysql:Z
       restart: always
 
   mysql-siroco:
@@ -35,7 +35,7 @@ services:
       ports:
         - "3003:3306"
       volumes:
-        - ./mysql_siroco:/var/lib/mysql
+        - ./mysql_siroco:/var/lib/mysql:Z
       restart: always
 
   dnf-cain:
@@ -79,8 +79,8 @@ services:
       - 11011:11011/udp           # df_game_r[ch.11]
       - 2111-2113:2111-2113/udp   # df_stun_r
     volumes:
-      - ./data_1:/data
-      - ./log_1:/home/neople/game/log
+      - ./data_1:/data:Z
+      - ./log_1:/home/neople/game/log:Z
 
   dnf-diregie:
     image: 1995chen/dnf:centos5-2.1.9.fix1
@@ -122,8 +122,8 @@ services:
       - 21012:21012/udp           # df_game_r[ch.12]
       - 2211-2213:2211-2213/udp   # df_stun_r
     volumes:
-      - ./data_2:/data
-      - ./log_2:/home/neople/game/log
+      - ./data_2:/data:Z
+      - ./log_2:/home/neople/game/log:Z
 
   dnf-siroco:
     image: 1995chen/dnf:centos5-2.1.9.fix1
@@ -164,5 +164,5 @@ services:
       - 31052:31052/udp           # df_game_r[ch.52]
       - 2311-2313:2311-2313/udp   # df_stun_r
     volumes:
-      - ./data_3:/data
-      - ./log_3:/home/neople/game/log
+      - ./data_3:/data:Z
+      - ./log_3:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/multi_server_group/diregie.yaml
+++ b/deploy/dnf/docker-compose/multi_server_group/diregie.yaml
@@ -43,5 +43,5 @@ services:
       - 21052:21052/udp           # df_game_r[ch.52]
       - 2211-2213:2211-2213/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./log:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/multi_server_group/siroco.yaml
+++ b/deploy/dnf/docker-compose/multi_server_group/siroco.yaml
@@ -43,5 +43,5 @@ services:
       - 31052:31052/udp           # df_game_r[ch.52]
       - 2311-2313:2311-2313/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./log:/home/neople/game/log:Z

--- a/deploy/dnf/docker-compose/standalone_mysql/docker-compose.yaml
+++ b/deploy/dnf/docker-compose/standalone_mysql/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       ports:
         - "3000:3306"
       volumes:
-        - ./mysql:/var/lib/mysql
+        - ./mysql:/var/lib/mysql:Z
       restart: always
 
   dnf-1:
@@ -57,5 +57,5 @@ services:
       - 31052:31052/udp           # df_game_r[ch.52]
       - 2311-2313:2311-2313/udp   # df_stun_r
     volumes:
-      - ./data:/data
-      - ./log:/home/neople/game/log
+      - ./data:/data:Z
+      - ./log:/home/neople/game/log:Z

--- a/doc/Kubernetes.md
+++ b/doc/Kubernetes.md
@@ -1,5 +1,9 @@
 # Kubernetes 部署DNF
 
+> 注意：Kubernetes 的 `volumeMounts` 不支持 Docker `-v` / Docker Compose 那种 `:Z` 挂载语法。
+>
+> 因此，Docker / Docker Compose 部署可以通过 `:Z` 兼容 SELinux，而 Kubernetes 部署需要依赖集群自身的存储类型、节点 SELinux 策略或 Pod `securityContext` 做适配；本项目文档不再要求为了部署 DNF 而全局关闭宿主机 SELinux。
+
 ## Yaml
 
 ```

--- a/doc/PrepareLinux.md
+++ b/doc/PrepareLinux.md
@@ -36,12 +36,6 @@ systemctl disable firewalld
 systemctl stop firewalld
 ```
 
-关闭 selinux
-
-```shell
-sudo sed -i 's/SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
-```
-
 ## 配置交换空间（若内存不足 8GB）
 
 创建 Swap 文件

--- a/plugin/by-gate/README.md
+++ b/plugin/by-gate/README.md
@@ -20,5 +20,5 @@ docker rm dnf
 
 我们将8188端口映射后，用新的启动命令启动，假设我们使用8188端口，那么启动命令如下：
 ```shell
-docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -v /data/log:/home/neople/game/log -v /data/mysql:/var/lib/mysql -v /data/data:/data -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 8188:8188/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 10011:10011/tcp -p 11011:11011/udp -p 10052:10052/tcp -p 11052:11052/udp -p 7200:7200/tcp -p 7200:7200/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.4.fix1
+docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -v /data/log:/home/neople/game/log:Z -v /data/mysql:/var/lib/mysql:Z -v /data/data:/data:Z -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 8188:8188/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 10011:10011/tcp -p 11011:11011/udp -p 10052:10052/tcp -p 11052:11052/udp -p 7200:7200/tcp -p 7200:7200/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.4.fix1
 ```

--- a/plugin/dnf-console/README.md
+++ b/plugin/dnf-console/README.md
@@ -18,5 +18,5 @@ docker rm dnf
 ## 重新启动
 我们将8088端口映射后，用新的启动命令启动，假设我们使用882端口，那么启动命令如下：
 ```shell
-docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -v /data/log:/home/neople/game/log -v /data/mysql:/var/lib/mysql -v /data/data:/data -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 882:8088/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 10011:10011/tcp -p 11011:11011/udp -p 10052:10052/tcp -p 11052:11052/udp -p 7200:7200/tcp -p 7200:7200/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.4.fix1
+docker run -d -e PUBLIC_IP=x.x.x.x -e WEB_USER=root -e WEB_PASS=123456 -e DNF_DB_ROOT_PASSWORD=88888888 -e GM_ACCOUNT=gmuser -e GM_PASSWORD=gmpass -v /data/log:/home/neople/game/log:Z -v /data/mysql:/var/lib/mysql:Z -v /data/data:/data:Z -p 2000:180 -p 3000:3306/tcp -p 7600:7600/tcp -p 881:881/tcp -p 882:8088/tcp -p 7001:7001/tcp -p 7001:7001/udp -p 10011:10011/tcp -p 11011:11011/udp -p 10052:10052/tcp -p 11052:11052/udp -p 7200:7200/tcp -p 7200:7200/udp -p 2311-2313:2311-2313/udp --cap-add=NET_ADMIN --hostname=dnf --cpus=1 --memory=1g --memory-swap=-1 --shm-size=8g --name=dnf 1995chen/dnf:centos5-2.1.4.fix1
 ```


### PR DESCRIPTION
## 变更说明

这个 PR 调整了项目中的部署文档和示例配置，使部署 DNF 时不再要求先关闭宿主机 SELinux。

具体改动包括：

- 删除 `doc/PrepareLinux.md` 中关闭 SELinux 的步骤
- 为 README、插件说明和 Docker Compose 示例中的 Docker bind mount 补充 `:Z`
- 在 `doc/Kubernetes.md` 中补充说明：Kubernetes 不支持 Docker / Docker Compose 的 `:Z` 挂载语法，需要由集群侧自行适配

## 背景

当前文档将“关闭宿主机 SELinux”作为部署前置步骤，这个做法过于激进，也会扩大宿主机安全面。

对于 Docker / Docker Compose 部署，bind mount 使用 `:Z` 后即可完成目录 relabel，通常不再需要通过关闭宿主机 SELinux 来规避权限问题。

## 影响范围

本次仅修改文档和示例配置，不涉及镜像内容、服务逻辑或运行时行为变更。
